### PR TITLE
[Fix] amz설정 주석처리가 아니라 아예 삭제

### DIFF
--- a/src/pages/user/projects/CreateRequest.tsx
+++ b/src/pages/user/projects/CreateRequest.tsx
@@ -146,7 +146,6 @@ const CreateRequest: React.FC = () => {
                 axios.put(entry.presignedUrl, formData.files[i], {
                   headers: { 
                     'Content-Type': formData.files[i].type
-                    // 'x-amz-acl': 'public-read'
                    },
                 })
               )


### PR DESCRIPTION
# 요약
- amz설정 주석처리가 아니라 아예 삭제

# 연관 이슈
#211 